### PR TITLE
Switch order of validators in eyeswanted POST

### DIFF
--- a/server/eyeswanted/router.ts
+++ b/server/eyeswanted/router.ts
@@ -45,8 +45,8 @@ router.post(
   '/',
   [
     userValidator.isUserLoggedIn,
-    updateValidator.isUpdateInActiveProject,
     updateValidator.isUpdateExistsBody,
+    updateValidator.isUpdateInActiveProject,
     updateValidator.isUpdateAuthorBody,
   ],
   async (req: Request, res: Response) => {


### PR DESCRIPTION
Checks that update exists before checking that it is part of an active project (which assumes it exists)