### PR TITLE
Make update details a side panel instead of new page

### DIFF
--- a/client/App.vue
+++ b/client/App.vue
@@ -22,6 +22,7 @@ export default {
       this.$store.commit('setEmail', user ? user.email : null);
       this.$store.commit('setLastname', user ? user.lastName : null);
       this.$store.commit('setFirstname', user ? user.firstName : null);
+      this.$store.commit('refreshProjects');
     });
     this.$store.commit('refreshAllThanks');
     this.$store.commit('refreshAllEyesWanted');
@@ -160,10 +161,42 @@ button.thin-btn {
   background: #F8F8F8;
   padding: 24px;
   cursor: pointer;
-  width: inherit;
 }
 
 .preview:hover {
   background: #f0eef0;
+}
+
+main.left-panel {
+  margin: 0 0 0 17%;
+  display: inline-block;
+  transition: width 1ms ease-in-out;
+  background-color: #fff;
+  padding-right: 20px;
+}
+main.left-panel.thin {
+  width: 50%;
+}
+.details-container {
+  display: inline-block;
+  position: fixed;
+  top: 0;
+  right: 0;
+  background-color: #f8f8f8;
+  border-left: 2px solid #a4a4a4;
+  width: 17%;
+  height: 100%;
+  margin-left: 8px;
+  padding: 40px 36px;
+}
+
+.details-container > button {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  text-decoration: underline;
+}
+main.left-panel.thin + .details-container {
+  width: 33%;
 }
 </style>

--- a/client/App.vue
+++ b/client/App.vue
@@ -28,6 +28,20 @@ export default {
     this.$store.commit('refreshEyesWanted');
     // Clear alerts on page refresh
     this.$store.state.alerts = {};
+  },
+  watch: {
+    '$route': {
+      handler: function(value) {
+        const validRoutes = [
+          'Updates', 'UpdatesPerUser', 'UpdateDetails',
+        ];
+        if (!validRoutes.includes(value.name)) {
+          this.$store.commit('setCurrentUpdate', null);
+        }
+      },
+      deep: true,
+      immediate: true,
+    },
   }
 };
 </script>
@@ -146,6 +160,7 @@ button.thin-btn {
   background: #F8F8F8;
   padding: 24px;
   cursor: pointer;
+  width: inherit;
 }
 
 .preview:hover {

--- a/client/components/EyesWanted/CompleteEyesWanted.vue
+++ b/client/components/EyesWanted/CompleteEyesWanted.vue
@@ -8,7 +8,6 @@
         Read!
       </button>
     </section>
-
       <section class="alerts">
         <article
           v-for="(status, alert, index) in alerts"
@@ -55,13 +54,20 @@
           if (!r.ok) {
             throw new Error(res.error);
           }
-          const message = `Successfully read update!`;
-          this.$set(this.alerts, message, 'success');
+          const message = ``;
+          if (this.eyeswanted.update._id === this.$store.state.currentUpdate?._id) {
+            this.$store.commit('setCurrentUpdate', null);  
+          }
           this.$store.commit('refreshEyesWanted');
-          setTimeout(() => this.$delete(this.alerts, message), 3000);
+          this.$store.commit('alert', {
+            status: 'success',
+            message: 'Successfully marked update as read!'
+          });
         } catch (e) {
-          this.$set(this.alerts, e, 'error');
-          setTimeout(() => this.$delete(this.alerts, e), 3000);
+          this.$store.commit('alert', {
+            status: 'error',
+            message: e
+          });
         };
       },
     },

--- a/client/components/Home/HomePage.vue
+++ b/client/components/Home/HomePage.vue
@@ -1,30 +1,26 @@
 <template>
-  <main class="home">
-    <div v-if="$store.state.email">
-      <ReadingList/>
-    </div>
-    <template v-else="$store.state.email">
-      <h2>Welcome to Standup!</h2>
-      <h3>A team project management application for students</h3>
-      <article v-if="showCreate">
-        <RegisterForm/>
-        <p>
-          Already have an account?
-          <a @click="showCreate = false">
-            Sign in
-          </a>
-        </p>
-      </article>
-      <article v-else>
-        <LoginForm/>
-        <p>
-          New to Standup?
-          <a @click="showCreate = true">
-            Create an account
-          </a>
-        </p>
-      </article>
-    </template>
+  <ReadingList v-if="$store.state.email"/>
+  <main class="home" v-else>
+    <h2>Welcome to Standup!</h2>
+    <h3>A team project management application for students</h3>
+    <article v-if="showCreate">
+      <RegisterForm/>
+      <p>
+        Already have an account?
+        <a @click="showCreate = false">
+          Sign in
+        </a>
+      </p>
+    </article>
+    <article v-else>
+      <LoginForm/>
+      <p>
+        New to Standup?
+        <a @click="showCreate = true">
+          Create an account
+        </a>
+      </p>
+    </article>
   </main>
 </template>
 

--- a/client/components/Home/Readinglist.vue
+++ b/client/components/Home/Readinglist.vue
@@ -1,26 +1,41 @@
 <template>
-    <main>
+  <div class="container">
+    <main class="left-panel" :class="{thin: $store.state.currentUpdate}">
       <h1>
         Reading List
       </h1>
       <template
       v-for="eyeswanted in $store.state.eyeswanted">
-      <UpdatePreview :update="eyeswanted.update" />
+      <UpdatePreview
+        :update="eyeswanted.update"
+        :openUpdate="openUpdate" />
     </template>
     <article v-if="$store.state.eyeswanted.length===0">
-        <p> No eyes wanted updates. </p>
+      <p> No eyes wanted updates. </p>
     </article>
     </main>
+    <div class="details-container" v-show="$store.state.currentUpdate">
+      <button @click="hideUpdate" class="text-btn thin-btn">
+        Hide >
+      </button>
+      <UpdateDetailPage
+        v-if="$store.state.currentUpdate"
+        class="update-details"
+        :showProjectTitle="true"
+        :project="$store.state.projects.find(p => p._id === $store.state.currentUpdate.projectId)"
+        :update="$store.state.currentUpdate"
+      />
+    </div>
+  </div>
   </template>
   
   <script>
   import UpdatePreview from '@/components/Update/UpdatePreview.vue';
-  // import GetCurrentProject from '@/components/Update/GetCurrentProject.vue';
+  import UpdateDetailPage from '@/components/Update/UpdateDetailPage.vue';
   
   export default {
     name: 'ReadingList',
-    // mixins: [GetCurrentProject],
-    components: {UpdatePreview},
+    components: {UpdatePreview, UpdateDetailPage},
     beforeMount() {
       this.$store.commit('refreshEyesWanted');
     },
@@ -28,6 +43,18 @@
       eyeswanted() {
         const eyeswanted = this.$store.state.eyeswanted || [];
         return eyeswanted;
+      }
+    },
+    methods: {
+      openUpdate(update) {
+        if (update === this.$store.state.currentUpdate) {
+          this.$store.commit('setCurrentUpdate', null);  
+          return;
+        }
+        this.$store.commit('setCurrentUpdate', update);
+      },
+      hideUpdate() {
+        this.$store.commit('setCurrentUpdate', null);
       }
     },
   }

--- a/client/components/Update/UpdateDetailPage.vue
+++ b/client/components/Update/UpdateDetailPage.vue
@@ -1,5 +1,6 @@
 <template>
     <section class="update">
+      <h2 v-if="showProjectTitle">{{ project.projectName }}</h2>
       <div v-if="editing">
         <div class=field>
           <UpdateForm :fields="draft">
@@ -127,7 +128,8 @@ export default {
     project: {
       type: Object,
       required: true,
-    }
+    },
+    showProjectTitle: Boolean,
   },
   computed: {
     inReadingList() {

--- a/client/components/Update/UpdateDetailPage.vue
+++ b/client/components/Update/UpdateDetailPage.vue
@@ -1,11 +1,73 @@
 <template>
-  <div class="container">
-    <UpdateSidebar :project="project"/>
-    <main>
-      <h1>
-        Project: {{ project.projectName }}
-      </h1>
-      <section class="update">
+    <section class="update">
+      <div v-if="editing">
+        <div class=field>
+          <UpdateForm :fields="draft">
+            <template #header>
+              Edit Update
+            </template>
+            <template #submit>
+              <div class="edit-btns">
+                <button
+                  class="thin-btn invert"
+                  @click="saveEdits">
+                  ✅ Save
+                </button>
+                <button
+                  class="thin-btn invert"
+                  @click="stopEditing">
+                  🚫 Discard
+                </button>
+                <button
+                  class="thin-btn invert"
+                  @click="deleteUpdate">
+                  🗑️ Delete
+                </button>
+              </div>
+            </template>
+          </UpdateForm>
+        </div>
+      </div>
+      <div class="update-metadata" v-else>
+        <h2>{{ update.summary }}</h2>
+        <div class="field">
+          <h4>From</h4>
+          <p>{{ update.author.firstName }} {{ update.author.lastName }}</p>
+          <p>{{ update.author.email }}</p>
+        </div>
+        <div class="field">
+          <h4>Last edited</h4>
+          <p>{{ update.dateModified }}</p>
+        </div>
+        <div class="field">
+          <h4>Status</h4>
+          <p class="status" :class="statusToText[update.status]">
+            {{ statusToText[update.status] }}
+          </p>
+        </div>
+        <div 
+          v-if="($store.state.email === update.author.email
+                  && project.active === true)"
+          class="eyeswanted">
+          <AddEyesWantedComponent
+          :update="update"
+          :project="project"/>
+        </div>
+        <div class="field">
+          <h4>Details</h4>
+          <p>{{ update.details }}</p>
+        </div>
+        <div class="action-items field">
+          <h4>Action Items</h4>
+          <ul class="reset">
+            <li
+              v-for="item in update.actionItems"
+            >
+              {{ item }}
+            </li>
+          </ul>
+          <p v-if="!update.actionItems.length">No action items were specified.</p>
+        </div>
         <div
           class="edit-btns"
           v-if="(update.author.email === $store.state.email && !editing)"
@@ -21,97 +83,32 @@
             🗑️ Delete
           </button>
         </div>
-        <div v-if="editing">
-          <div class="field">
-            <UpdateForm :fields="draft">
-              <template #header>
-                Edit update form
-              </template>
-              <template #submit>
-                <div class="edit-btns">
-                  <button
-                    class="thin-btn invert"
-                    @click="saveEdits">
-                    ✅ Save
-                  </button>
-                  <button
-                    class="thin-btn invert"
-                    @click="stopEditing">
-                    🚫 Discard
-                  </button>
-                  <button
-                    class="thin-btn invert"
-                    @click="deleteUpdate">
-                    🗑️ Delete
-                  </button>
-                </div>
-              </template>
-            </UpdateForm>
-          </div>
-        </div>
-      <div class="update-metadata" v-else>
-        <h2>
-          {{ update.summary }}
-        </h2>
-        <p class="metadata">
-          {{ update.author.firstName }} {{ update.author.lastName }} ({{ update.author.email }})
-          <br></br>
-          {{ update.dateModified }}
-        </p>
-        <p class="status" :class="statusToText[update.status]">
-          {{ statusToText[update.status] }}
-        </p>
+        </br>
         <div 
-          v-if="($store.state.email === update.author.email
-                  && project.active === true)"
+          v-if="inReadingList"
           class="eyeswanted">
-          <AddEyesWantedComponent
+          <CompleteEyesWantedComponent
           :update="update"
-          :project="project"/>
+          :eyeswanted="this.eyeswanted"/>
         </div>
-        <h3>Details</h3>
-        <p>
-          {{ update.details }}
-        </p>
-        <div class="action-items">
-          <h3>Action Items</h3>
-          <ul class="reset">
-            <li
-              v-for="item in update.actionItems"
-            >
-              {{ item }}
-            </li>
-          </ul>
-          <p v-if="!update.actionItems.length">No action items were specified.</p>
+        <div 
+          v-if="($store.state.email !== update.author.email
+                  && project.active === true)"
+          class="thanks">
+          <AddThanksComponent
+          :update="update"/>
         </div>
-      </div>
-      </br>
-      <div 
-        v-if="inReadingList"
-        class="eyeswanted">
-        <CompleteEyesWantedComponent
-        :update="update"
-        :eyeswanted="this.eyeswanted"/>
-      </div>
-      <div 
-        v-if="($store.state.email !== update.author.email
-                && project.active === true)"
-        class="thanks">
-        <AddThanksComponent
-        :update="update"/>
-      </div>
-      <div
-        v-if="(this.update.author.email === $store.state.email && isThankedby())">
-        <p class="thanks-number">
-        {{ this.thanks.length }} thanks </p>
-        <p v-for="thanks in this.thanks"
-          class="thanks-number">
-          by {{ thanks.postUser.firstName }} {{thanks.postUser.lastName}}
-        </p>
+        <div
+          v-if="(this.update.author.email === $store.state.email && isThankedby())">
+          <p class="thanks-number">
+          {{ this.thanks.length }} thanks </p>
+          <p v-for="thanks in this.thanks"
+            class="thanks-number">
+            by {{ thanks.postUser.firstName }} {{thanks.postUser.lastName}}
+          </p>
+        </div>
       </div>
     </section>
-  </main>
-</div>
 </template>
 <script>
 import UpdateForm from '@/components/Update/UpdateForm.vue';
@@ -123,6 +120,15 @@ import UpdateSidebar from '@/components/Update/UpdateSidebar.vue';
 export default {
   name: 'UpdateDetailPage',
   components: {UpdateForm, UpdateSidebar, AddThanksComponent, AddEyesWantedComponent, CompleteEyesWantedComponent},
+  props: {
+    update: {
+      type: Object,
+    },
+    project: {
+      type: Object,
+      required: true,
+    }
+  },
   computed: {
     inReadingList() {
       const eyeswanted = this.$store.state.eyeswanted;
@@ -131,22 +137,6 @@ export default {
     },
   },
   methods: {
-    findFields(projectId, updateId) {
-      if (!(projectId in this.$store.state.updates)) {
-        return null;
-      }
-      const project = this.$store.state.projects.find(
-          proj => proj._id === projectId);
-      const update = (this.$store.state.updates[projectId] || []).find(
-          u => u._id === updateId);
-      return {project, update};
-    },
-    // Redirect if the corresponding update does not exist
-    verifyUpdate() {
-      if (!this.update) {
-        this.$router.push({name: 'Not Found'});
-      }
-    },
     isThankedby() {
       const allthanks = this.$store.state.allthanks;
       this.thanks = allthanks.filter(thanks => thanks.updateId._id === this.update._id);
@@ -185,12 +175,12 @@ export default {
         credentials: 'same-origin',
         body: JSON.stringify({
           ...this.draft,
-          projectId: this.$route.params.id,
+          projectId: this.project._id,
         }),
       };
       try {
         const res = await fetch(
-          `/api/updates/${this.$route.params.updateId}`, options);
+          `/api/updates/${this.update._id}`, options);
         const resJson = await res.json();
         if (!res.ok) {
           throw Error(resJson.error);
@@ -199,7 +189,8 @@ export default {
           status: 'success',
           message: 'Successfully updated update!',
         });
-        this.$store.commit('refreshUpdates', this.$route.params.id);
+        this.$store.commit('refreshUpdates', this.project._id);
+        this.$store.commit('setCurrentUpdate', resJson.update);
         this.stopEditing();
       } catch (e) {
         this.$store.commit('alert', {
@@ -216,7 +207,7 @@ export default {
       };
       try {
         const res = await fetch(
-          `/api/updates/${this.$route.params.updateId}`, options);
+          `/api/updates/${this.update._id}`, options);
         const resJson = await res.json();
         if (!res.ok) {
           throw Error(resJson.error);
@@ -225,13 +216,8 @@ export default {
           status: 'success',
           message: 'Successfully deleted update!',
         });
-        this.$store.commit('refreshUpdates', this.$route.params.id);
-        this.$router.push({
-          name: 'Updates',
-          params: {
-            id: this.$route.params.id,
-          }
-        });  
+        this.$store.commit('refreshUpdates', this.project._id);
+        this.$store.commit('setCurrentUpdate', null);
       } catch (e) {
         this.$store.commit('alert', {
           status: 'error',
@@ -241,13 +227,9 @@ export default {
     },
   },
   data() {
-    const {project, update} = this.findFields(
-        this.$route.params.id, this.$route.params.updateId);
     return {
-      update,
-      project,
       editing: false,
-      draft: update,
+      draft: this.update,
       alerts: {}, // Displays success/error messages encountered during update modification
       statusToText: {
         'inprogress': 'In-Progress',
@@ -256,33 +238,10 @@ export default {
       },
     }
   },
-  watch: {
-    "$route.params": {
-      handler: function(value) {
-        const {id, updateId} = value;
-        const {project, update} = this.findFields(
-          id, updateId);
-        this.project = project;
-        this.update = update;
-        this.verifyUpdate();
-      },
-      deep: true,
-      immediate: true,
-    },
-    "$store.state.updates": {
-      handler: function(value) {
-        const { update } = this.findFields(
-          this.$route.params.id, this.$route.params.updateId);
-        this.update = update;
-        this.verifyUpdate();
-      },
-      deep: true,
-      immediate: true,
-    },
-  },
 }
 </script>
 <style scoped>
+
 .update ul.reset,
 .update ul.reset li {
   list-style-type: disc;
@@ -300,12 +259,18 @@ export default {
 .update {
   position: relative;
 }
+
 .update .edit-btns {
-  position: absolute;
-  top: 0;
-  right: 12px;
+  margin-top: 12px;
 }
 .edit-btns button + button {
   margin-left: 8px;
+}
+.update-metadata .field p,
+.update-metadata .field h4 {
+  margin: 4px 0;
+}
+.update-metadata .field {
+  margin-bottom: 20px;
 }
 </style>

--- a/client/components/Update/UpdateForm.vue
+++ b/client/components/Update/UpdateForm.vue
@@ -114,10 +114,6 @@ section {
   position: relative;
 }
 
-section h2 {
-  margin-top: 0;
-}
-
 .field {
   margin-bottom: 12px;
 }

--- a/client/components/Update/UpdatePreview.vue
+++ b/client/components/Update/UpdatePreview.vue
@@ -1,5 +1,5 @@
 <template>
-  <article class="update preview" @click="openUpdate">
+  <article class="update preview" @click="openUpdate(update)">
     <div>
       {{ update.dateModified }}: 
       {{ update.summary }}
@@ -20,7 +20,6 @@
 </template>
 
 <script>
-import AddEyesWantedComponent from '@/components/EyesWanted/AddEyesWanted.vue';
 export default {
   name: 'UpdatePreview',
   props: {
@@ -28,6 +27,10 @@ export default {
       type: Object,
       required: true,
     },
+    openUpdate: {
+      type: Function,
+      required: true,
+    }
   },
   data()  {
     return {
@@ -45,15 +48,6 @@ export default {
       this.thanks = allthanks.filter(thanks => thanks.updateId._id === this.update._id);
       return this.thanks;
     },
-    openUpdate() {
-      this.$router.push({
-        name: 'UpdateDetails',
-        params: {
-          id: this.update.projectId,
-          updateId: this.update._id,
-        },
-      })
-    }
   }
 }
 </script>

--- a/client/components/Update/UpdatesPage.vue
+++ b/client/components/Update/UpdatesPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container">
     <UpdateSidebar :project="project"/>
-    <main :class="{thin: $store.state.currentUpdate}">
+    <main class="left-panel" :class="{thin: $store.state.currentUpdate}">
       <h1>
         Project: {{ project.projectName }}
       </h1>
@@ -23,17 +23,17 @@
         </p>
       </section>
     </main>
-      <div class="details-container" v-show="$store.state.currentUpdate">
-        <button @click="hideUpdate" class="text-btn thin-btn">
-          Hide >
-        </button>
-        <UpdateDetailPage
-          v-if="$store.state.currentUpdate"
-          class="update-details"
-          :project="project"
-          :update="$store.state.currentUpdate"
-        />
-      </div>
+    <div class="details-container" v-show="$store.state.currentUpdate">
+      <button @click="hideUpdate" class="text-btn thin-btn">
+        Hide >
+      </button>
+      <UpdateDetailPage
+        v-if="$store.state.currentUpdate"
+        class="update-details"
+        :project="project"
+        :update="$store.state.currentUpdate"
+      />
+    </div>
   </div>
 </template>
 
@@ -100,37 +100,5 @@ export default {
   flex-grow: 1;
 }
 
-main {
-  margin: 0 0 0 17%;
-  display: inline-block;
-  transition: width 1ms ease-in-out;
-  background-color: #fff;
-  padding-right: 20px;
-}
-main.thin {
-  width: 50%;
-}
-.details-container {
-  display: inline-block;
-  position: fixed;
-  top: 0;
-  right: 0;
-  background-color: #f8f8f8;
-  border-left: 2px solid #a4a4a4;
-  width: 17%;
-  height: 100%;
-  margin-left: 8px;
-  padding: 40px 36px;
-}
-
-.details-container > button {
-  position: absolute;
-  top: 16px;
-  right: 16px;
-  text-decoration: underline;
-}
-main.thin + .details-container {
-  width: 33%;
-}
 
 </style>

--- a/client/components/Update/UpdatesPage.vue
+++ b/client/components/Update/UpdatesPage.vue
@@ -1,40 +1,57 @@
 <template>
   <div class="container">
     <UpdateSidebar :project="project"/>
-    <main>
+    <main :class="{thin: $store.state.currentUpdate}">
       <h1>
         Project: {{ project.projectName }}
       </h1>
+      <button
+        v-if="project.active"
+        class="add-update-btn"
+        @click="goToAddForm"
+      >+ Add Update</button>
       <section
         v-for="(updateList, key) in updates"
         class="user-updates"
       >
         <h2>{{ key }}</h2>
         <template v-for="update in updateList">
-          <UpdatePreview :update="update" />
+          <UpdatePreview :update="update" :openUpdate="openUpdate"/>
         </template>
         <p v-if="!updateList.length">
           No updates have been shared.
         </p>
       </section>
-      <button
-        v-if="project.active"
-        class="add-update-btn"
-        @click="goToAddForm"
-      >+ Add Update</button>
     </main>
+      <div class="details-container" v-show="$store.state.currentUpdate">
+        <button @click="hideUpdate" class="text-btn thin-btn">
+          Hide >
+        </button>
+        <UpdateDetailPage
+          v-if="$store.state.currentUpdate"
+          class="update-details"
+          :project="project"
+          :update="$store.state.currentUpdate"
+        />
+      </div>
   </div>
 </template>
 
 <script>
 import UpdatePreview from '@/components/Update/UpdatePreview.vue';
+import UpdateDetailPage from '@/components/Update/UpdateDetailPage.vue';
 import GetCurrentProject from '@/components/Update/GetCurrentProject.vue';
 import UpdateSidebar from '@/components/Update/UpdateSidebar.vue';
 
 export default {
   name: 'UpdatesPage',
   mixins: [GetCurrentProject],
-  components: {UpdatePreview, UpdateSidebar},
+  components: {UpdatePreview, UpdateSidebar, UpdateDetailPage},
+  data() {
+    return {
+      currentUpdate: null,
+    }
+  },
   beforeMount() {
     this.$store.commit('refreshUpdates', this.$route.params.id);
   },
@@ -47,6 +64,21 @@ export default {
         }
       });
     },
+    openUpdate(update) {
+      if (update === this.$store.state.currentUpdate) {
+        this.hideUpdate();
+      } else {
+        this.$store.commit('setCurrentUpdate', update);
+      }
+    },
+    hideUpdate(update) {
+      this.$store.commit('setCurrentUpdate', null);
+    }
+  },
+  computed: {
+    updates() {
+      return {};
+    }
   }
 }
 </script>
@@ -55,13 +87,50 @@ export default {
 .user-updates {
   padding-bottom: 8px;
 }
-
-.add-update-btn {
-  position: fixed;
-  right: 20px;
-  bottom: 20px;
-}
 .container {
   position: relative;
+  display: flex;
 }
+
+.container header {
+  display: flex;
+  align-items: center;
+}
+.container header h1 {
+  flex-grow: 1;
+}
+
+main {
+  margin: 0 0 0 17%;
+  display: inline-block;
+  transition: width 1ms ease-in-out;
+  background-color: #fff;
+  padding-right: 20px;
+}
+main.thin {
+  width: 50%;
+}
+.details-container {
+  display: inline-block;
+  position: fixed;
+  top: 0;
+  right: 0;
+  background-color: #f8f8f8;
+  border-left: 2px solid #a4a4a4;
+  width: 17%;
+  height: 100%;
+  margin-left: 8px;
+  padding: 40px 36px;
+}
+
+.details-container > button {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  text-decoration: underline;
+}
+main.thin + .details-container {
+  width: 33%;
+}
+
 </style>

--- a/client/components/Update/UpdatesPage.vue
+++ b/client/components/Update/UpdatesPage.vue
@@ -22,7 +22,7 @@
         class="add-update-btn"
         @click="goToAddForm"
       >+ Add Update</button>
-      </main>
+    </main>
   </div>
 </template>
 

--- a/client/components/common/NavBar.vue
+++ b/client/components/common/NavBar.vue
@@ -3,7 +3,7 @@
 <!-- This navbar takes advantage of both flex and grid layouts for positioning elements; feel free to redesign as you see fit! -->
 
 <template>
-  <nav>
+  <nav :class="{thin: $store.state.currentUpdate}">
     <div class="left">
       <img src="../../public/logo.svg">
       <h1 class="title">
@@ -75,5 +75,9 @@ img {
 
 .alerts {
     width: 25%;
+}
+
+nav.thin {
+  margin-right: 33%;
 }
 </style>

--- a/client/store.ts
+++ b/client/store.ts
@@ -21,6 +21,7 @@ const store = new Vuex.Store({
     eyeswanted: [], // mapping from user to a list of eyes wanted updates
     alleyeswanted: [], // All eyes wanted in the app
     userFilter: null,
+    currentUpdate: null,
   },
   mutations: {
     alert(state, payload) {
@@ -59,6 +60,9 @@ const store = new Vuex.Store({
        * @param filter - Username of the user to fitler freets by
        */
       state.filter = filter;
+    },
+    setCurrentUpdate(state, update) {
+      state.currentUpdate = update;
     },
     updateProjects(state, projects) {
       /**


### PR DESCRIPTION
- The side panel is fixed on the page
- Clicking on an update allows u to view the details
- Clicking on an update while it is alrdy open will close it
- Navigating to a page outside of the project will also close it
- ReadingList also opens update as a side panel
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/42757189/206592295-c29e72e7-4fc0-4219-8cde-0dc55bdb4c7d.png">
