### PR TITLE
Emergency fixes to deletion, plus small changes

### DIFF
--- a/client/App.vue
+++ b/client/App.vue
@@ -69,7 +69,7 @@ main {
 
 .alerts {
     position: absolute;
-    z-index: 99;
+    z-index: 9999;
     bottom: 0;
     top: 100%;
     left: 50%;

--- a/client/components/EyesWanted/AddEyesWanted.vue
+++ b/client/components/EyesWanted/AddEyesWanted.vue
@@ -6,7 +6,7 @@
         v-if="!existingEyesWanted || !waitingFor.length"
         @click="addEyesWanted"
       >
-        {{!waitingFor.length ? 'Re-mark ' : ''}} Eye's wanted!
+        {{!waitingFor.length ? 'Re-mark ' : ''}} Eyes wanted!
       </button>
       <button class="addeyeswantedbutton thin-btn invert"
         v-if="existingEyesWanted && waitingFor.length"

--- a/client/components/Project/ProjectInvitesComponent.vue
+++ b/client/components/Project/ProjectInvitesComponent.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <button @click="showModal">
-      Project Invites
+      Project Invites ({{ $store.state.invites ? $store.state.invites.length : 0 }})
     </button>
     <Modal
       v-if="show"

--- a/server/eyeswanted/collection.ts
+++ b/server/eyeswanted/collection.ts
@@ -161,8 +161,11 @@ class EyesWantedCollection {
    * @return {Promise<Boolean>} - true if the EyesWanteds have been deleted, false otherwise
    */
    static async deleteMany(updateIds: Types.ObjectId[] | string[]): Promise<boolean> {
-    const eyesWanteds = await EyesWantedModel.deleteMany({ updateId: { $in: updateIds } });
-    return eyesWanteds !== null;
+    if (updateIds.length) {
+      const eyesWanteds = await EyesWantedModel.deleteMany({ updateId: { $in: updateIds } });
+      return eyesWanteds !== null;
+    }
+    return false;
   }
 }
 

--- a/server/thanks/collection.ts
+++ b/server/thanks/collection.ts
@@ -95,7 +95,9 @@ class ThanksCollection {
    * @param {Types.ObjectId[] | string[]} updateIds - The id of the updates
    */
    static async deleteManybyUpdateIds(updateIds: Types.ObjectId[] | string[]): Promise<void> {
-    await ThanksModel.deleteMany({ updateId: { $in: updateIds } });
+    if (updateIds.length) {
+      await ThanksModel.deleteMany({ updateId: { $in: updateIds } });
+    }
   }
 
   /**

--- a/server/update/collection.ts
+++ b/server/update/collection.ts
@@ -74,7 +74,10 @@ class UpdateCollection {
    * @return {Promise<HydratedDocument<Update>[]>} - The updates with the given projectId
    */
    static async findAllByProjectIds(projectIds: Types.ObjectId[] | string[]): Promise<HydratedDocument<Update>[]> {
-    return UpdateModel.find({ projectId: { $in: projectIds } }).sort({ dateCreated: -1 }).populate('authorId');
+    if (projectIds.length) {
+      return UpdateModel.find({ projectId: { $in: projectIds } })
+    }
+    return [];
   }
 
   /**
@@ -158,8 +161,11 @@ class UpdateCollection {
    * @return {Promise<Boolean>} - true if the update has been deleted, false otherwise
    */
    static async deleteMany(updateIds: Types.ObjectId[] | string[]): Promise<boolean> {
-    const updates = await UpdateModel.deleteMany({ updateId: { $in: updateIds } });
-    return updates !== null;
+    if (updateIds.length) {
+      const updates = await UpdateModel.deleteMany({ updateId: { $in: updateIds } });
+      return updates !== null;
+    }
+    return false;
   }
 
   /**


### PR DESCRIPTION
If the array passed to ```$in``` is empty, it will just delete everything in the array. Prevents this from happening.

Also adds a small number to count project invites and fixes typo from ```Eye's Wanted``` to ```Eyes Wanted``` (#42), and changes the ```z-index``` of ```alerts``` to ```9999``` so it can be seen even with a modal (#48).