### PR TITLE
Fixes DELETE for EyesWanted

### DIFF
--- a/server/eyeswanted/collection.ts
+++ b/server/eyeswanted/collection.ts
@@ -156,7 +156,7 @@ class EyesWantedCollection {
    * @return {Promise<Boolean>} - true if the EyesWanted has been deleted, false otherwise
    */
    static async deleteOne(eyesWantedId: Types.ObjectId | string): Promise<boolean> {
-    const eyesWanted = await EyesWantedModel.deleteOne({ eyesWantedId });
+    const eyesWanted = await EyesWantedModel.deleteOne({ _id: eyesWantedId });
     return eyesWanted !== null;
   }
 


### PR DESCRIPTION
Fixes a typo for ```deleteOne``` in ```EyesWantedCollection``` where it was deleting by ```eyesWantedId``` (which is not field in the model) instead of ```_id```.